### PR TITLE
Release/v1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 1.0.3
+
+### Fixed
+
+- Avoided writing `${{ github.token }}` in the description of GitHub Action.
+- Added `RunCommand` in `ElixirCommandRunner`.
+- Changed head option abbr to `c`.
+- Fixed String to int cast failure.
+- Fixed ignore analyze error.
+- Fixed `grep` command failure.
+- Use `original_commit_id` instead of `commit_id`.
+
 ## 1.0.2
 
 ### Fixed

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,0 +1,1 @@
+void main() {}

--- a/lib/gen/pubspec.dart
+++ b/lib/gen/pubspec.dart
@@ -4,7 +4,7 @@ import 'package:pubspec_parse/pubspec_parse.dart';
 
 final pubspec = Pubspec.parse("""name: elixir
 description: Tool for commenting `dart analyze` results to GitHub PullRequest.
-version: 1.0.2
+version: 1.0.3
 homepage: https://github.com/blendthink/elixir
 repository: https://github.com/blendthink/elixir
 documentation: https://github.com/blendthink/elixir

--- a/lib/util/log.dart
+++ b/lib/util/log.dart
@@ -6,7 +6,7 @@ class Log {
 An unexpected error occurred.
 Consider creating an issue on https://github.com/blendthink/elixir/issues/new.
 
-$o''' ;
+$o''';
     print('\x1B[31m$message\x1B[0m');
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: elixir
 description: Tool for commenting `dart analyze` results to GitHub PullRequest.
-version: 1.0.2
+version: 1.0.3
 homepage: https://github.com/blendthink/elixir
 repository: https://github.com/blendthink/elixir
 documentation: https://github.com/blendthink/elixir


### PR DESCRIPTION
## Overview

### Fixed

- Avoided writing `${{ github.token }}` in the description of GitHub Action.
- Added `RunCommand` in `ElixirCommandRunner`.
- Changed head option abbr to `c`.
- Fixed String to int cast failure.
- Fixed ignore analyze error.
- Fixed `grep` command failure.
- Use `original_commit_id` instead of `commit_id`.